### PR TITLE
feat: add site footer with extra_head/extra_footer injection hooks

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -736,6 +736,58 @@ details.admonition[open] > summary {
   color: var(--accent);
 }
 
+/* ── Site Footer ── */
+.site-footer {
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  padding: 0.875rem 2rem;
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-shrink: 0;
+  transition: background var(--transition), border-color var(--transition);
+}
+
+/* Mono at 0.7rem: same visual register as breadcrumbs and nav section labels */
+.footer-attribution {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.02em;
+  color: var(--text-3);
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+/* 1px typographic hairline — no image, inherits --border for dark mode */
+.footer-attribution::before {
+  content: '';
+  display: inline-block;
+  width: 1px;
+  height: 0.85em;
+  background: var(--border);
+  margin-right: 0.4rem;
+  transition: background var(--transition);
+}
+
+.footer-attribution a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+  transition: opacity var(--transition);
+}
+
+.footer-attribution a:hover {
+  opacity: 0.7;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* display:contents = zero layout impact; injected scripts stay invisible */
+.footer-extra {
+  display: contents;
+}
+
 /* ── Search Modal ── */
 .search-overlay {
   display: none;
@@ -912,6 +964,9 @@ details.admonition[open] > summary {
   }
   .pager {
     grid-template-columns: 1fr;
+  }
+  .site-footer {
+    padding: 0.875rem 1.5rem;
   }
   .content-title {
     font-size: 1.6rem;

--- a/docs/guide/01-configuration.md
+++ b/docs/guide/01-configuration.md
@@ -13,6 +13,12 @@ title    = "mylib"
 version  = "v1.4.2"
 base_url = "https://yourorg.github.io/mylib"
 repo     = "https://github.com/yourorg/mylib"
+extra_head = """
+<meta name="google-site-verification" content="abc123">
+"""
+extra_footer = """
+<script defer src="https://example.com/analytics.js"></script>
+"""
 
 [build]
 docs_dir   = "docs"
@@ -44,6 +50,26 @@ pages   = ["configuration.md", "routing.md"]
 | `version` | `""` | Optional version badge shown next to the title |
 | `base_url` | `""` | Canonical URL — used in sitemap and meta tags |
 | `repo` | `""` | GitHub URL — renders the GitHub icon in the header |
+| `extra_head` | `""` | Verbatim HTML injected into `<head>` — custom fonts, verification tags, etc. |
+| `extra_footer` | `""` | Verbatim HTML injected into the page footer — analytics scripts, banners, etc. |
+
+Use triple-quoted TOML strings for multi-line values:
+
+```toml
+[site]
+extra_head = """
+<meta name="google-site-verification" content="abc123">
+<link rel="preconnect" href="https://fonts.example.com">
+"""
+
+extra_footer = """
+<script defer src="https://example.com/analytics.js"></script>
+"""
+```
+
+::: warning
+`extra_head` and `extra_footer` are rendered unescaped. Only include HTML you trust.
+:::
 
 ## [build]
 

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -102,6 +102,7 @@ func loadTemplates(embFS fs.FS) (*template.Template, error) {
 		"templates/partials/sidebar.html",
 		"templates/partials/toc.html",
 		"templates/partials/pager.html",
+		"templates/partials/footer.html",
 		"templates/partials/dev-reload.html",
 	)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,10 +19,12 @@ type Config struct {
 
 // SiteConfig holds site-level metadata shown in every page.
 type SiteConfig struct {
-	Title   string `toml:"title"`
-	Version string `toml:"version"`
-	BaseURL string `toml:"base_url"`
-	Repo    string `toml:"repo"`
+	Title       string `toml:"title"`
+	Version     string `toml:"version"`
+	BaseURL     string `toml:"base_url"`
+	Repo        string `toml:"repo"`
+	ExtraHead   string `toml:"extra_head"`   // injected verbatim into <head> before </head>
+	ExtraFooter string `toml:"extra_footer"` // injected verbatim into <footer> after attribution
 }
 
 // BuildConfig controls where kwelea reads and writes files.

--- a/internal/nav/nav.go
+++ b/internal/nav/nav.go
@@ -2,6 +2,7 @@ package nav
 
 import (
 	"fmt"
+	"html/template"
 	"net/url"
 	"path/filepath"
 	"sort"
@@ -210,6 +211,8 @@ func NewSite(cfg *config.Config) (*Site, error) {
 		BasePath:     basePath,
 		Repo:         cfg.Site.Repo,
 		RepoPlatform: repoplatform(cfg.Site.Repo),
+		ExtraHead:    template.HTML(cfg.Site.ExtraHead),
+		ExtraFooter:  template.HTML(cfg.Site.ExtraFooter),
 		BuildCfg:     cfg.Build,
 		ServeCfg:     cfg.Serve,
 		ThemeCfg:     cfg.Theme,

--- a/internal/nav/types.go
+++ b/internal/nav/types.go
@@ -14,7 +14,9 @@ type Site struct {
 	BaseURL      string
 	BasePath     string // URL path prefix derived from BaseURL, e.g. "/kwelea" or ""
 	Repo         string
-	RepoPlatform string // "github", "gitlab", or "" for unknown/not set
+	RepoPlatform string        // "github", "gitlab", or "" for unknown/not set
+	ExtraHead    template.HTML // verbatim HTML injected into <head>; from kwelea.toml [site].extra_head
+	ExtraFooter  template.HTML // verbatim HTML injected into <footer>; from kwelea.toml [site].extra_footer
 	BuildCfg     config.BuildConfig
 	ServeCfg     config.ServeConfig
 	ThemeCfg     config.ThemeConfig

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -11,6 +11,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="{{.Site.BasePath}}/assets/favicon/favicon-16x16.png">
 <link rel="manifest" href="{{.Site.BasePath}}/assets/favicon/site.webmanifest">
 <link rel="shortcut icon" href="{{.Site.BasePath}}/assets/favicon/favicon.ico">
+{{if .Site.ExtraHead}}{{.Site.ExtraHead}}{{end}}
 </head>
 <body>
 
@@ -71,6 +72,8 @@
 </header>
 
 {{template "page" .}}
+
+{{template "footer" .}}
 
 <!-- Search Modal -->
 <div class="search-overlay" id="searchOverlay">

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -1,0 +1,9 @@
+{{define "footer"}}
+<footer class="site-footer">
+  <span class="footer-attribution">
+    Built with
+    <a href="https://github.com/engineervix/kwelea" target="_blank" rel="noopener noreferrer">kwelea</a>
+  </span>
+  {{if .Site.ExtraFooter}}<div class="footer-extra">{{.Site.ExtraFooter}}</div>{{end}}
+</footer>
+{{end}}


### PR DESCRIPTION
## Summary

- Adds a full-width `<footer>` below the three-column layout with a "Built with kwelea" attribution link
- Introduces `[site] extra_head` and `[site] extra_footer` in `kwelea.toml` for injecting arbitrary HTML into `<head>` and the page footer (verification tags, analytics scripts, custom fonts, etc.)
- Footer CSS uses only existing design-system custom properties — light/dark mode transitions work automatically, no hardcoded colours

## Changes

- `templates/partials/footer.html` — new partial
- `templates/layout.html` — `ExtraHead` injection in `<head>`, `{{template "footer" .}}` wired in
- `internal/config/config.go` — `ExtraHead`, `ExtraFooter string` added to `SiteConfig`
- `internal/nav/types.go` + `nav.go` — `ExtraHead`, `ExtraFooter template.HTML` on `Site`, mapped in `NewSite`
- `internal/builder/builder.go` — `footer.html` registered in `loadTemplates`
- `assets/theme.css` — footer styles + mobile responsive rule
- `docs/guide/01-configuration.md` — `[site]` table extended, usage example + warning admonition added

## Test plan

- [x] `kwelea serve` — footer renders below pager, full width
- [x] "Built with kwelea" link opens `https://github.com/engineervix/kwelea`
- [x] Toggle dark mode — footer border, text, and link colours transition correctly
- [x] Mobile (≤768px) — footer still readable, no overflow
- [x] Add `extra_head` / `extra_footer` to `kwelea.toml`, run `kwelea build`, confirm injected HTML appears in output

Closes #10