### PR TITLE
fix(server): reload kwelea.toml on change during serve

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -28,5 +28,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return server.Start(cfg, assets, cfgFile)
+	return server.Start(cfg, assets, cfgFile, func(c *config.Config) error {
+		return applyFlagOverrides(cmd, c)
+	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,7 +30,10 @@ const (
 //  4. Serves the output directory as a static site
 //  5. Opens the browser (unless disabled)
 //  6. Blocks until SIGINT/SIGTERM, then shuts down cleanly
-func Start(cfg *config.Config, embFS fs.FS, cfgPath string) error {
+//
+// applyOverrides is called on each config reload triggered by a kwelea.toml
+// change; it re-applies CLI flag values on top of the freshly loaded config.
+func Start(cfg *config.Config, embFS fs.FS, cfgPath string, applyOverrides func(*config.Config) error) error {
 	// Initial build so there's something to serve immediately.
 	if err := initialBuild(cfg, embFS); err != nil {
 		return err
@@ -50,7 +53,7 @@ func Start(cfg *config.Config, embFS fs.FS, cfgPath string) error {
 
 	srv := &http.Server{Handler: mux}
 
-	go watch(cfg, embFS, cfgPath, hub)
+	go watch(cfg, embFS, cfgPath, hub, applyOverrides)
 
 	addr := fmt.Sprintf("http://localhost:%d", port)
 	fmt.Printf("→ starting dev server on %s\n", addr)

--- a/internal/server/watcher.go
+++ b/internal/server/watcher.go
@@ -17,8 +17,10 @@ import (
 // watch starts an fsnotify watcher over docsDir (recursively) and cfgPath.
 // File-change events are debounced: after a 300 ms quiet period the site is
 // rebuilt in devMode and hub.Reload() broadcasts to connected browsers.
+// When cfgPath itself changes, the config is reloaded from disk and overrides
+// are re-applied before the next rebuild.
 // watch runs until the watcher is closed; it is intended to run in a goroutine.
-func watch(cfg *config.Config, embFS fs.FS, cfgPath string, hub *Hub) {
+func watch(cfg *config.Config, embFS fs.FS, cfgPath string, hub *Hub, applyOverrides func(*config.Config) error) {
 	w, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Printf("watcher: %v", err)
@@ -35,6 +37,7 @@ func watch(cfg *config.Config, embFS fs.FS, cfgPath string, hub *Hub) {
 
 	const debounce = 300 * time.Millisecond
 	var timer *time.Timer
+	currentCfg := cfg
 
 	for {
 		select {
@@ -46,6 +49,15 @@ func watch(cfg *config.Config, embFS fs.FS, cfgPath string, hub *Hub) {
 			if event.Has(fsnotify.Chmod) {
 				continue
 			}
+			// When kwelea.toml changes, reload it and re-apply CLI overrides.
+			if isConfigFile(event.Name, cfgPath) {
+				if fresh, err := reloadConfig(cfgPath, applyOverrides); err != nil {
+					log.Printf("watcher: config reload: %v", err)
+				} else {
+					currentCfg = fresh
+					log.Println("→ config reloaded")
+				}
+			}
 			// When a new directory is created inside docs/, start watching it too.
 			if event.Has(fsnotify.Create) {
 				if fi, err := os.Stat(event.Name); err == nil && fi.IsDir() {
@@ -53,11 +65,14 @@ func watch(cfg *config.Config, embFS fs.FS, cfgPath string, hub *Hub) {
 				}
 			}
 			// Debounce: reset the timer on every event.
+			// Snapshot currentCfg so the closure captures the value at this moment,
+			// avoiding a data race if currentCfg is updated before the timer fires.
 			if timer != nil {
 				timer.Stop()
 			}
+			snap := currentCfg
 			timer = time.AfterFunc(debounce, func() {
-				rebuildAndReload(cfg, embFS, hub)
+				rebuildAndReload(snap, embFS, hub)
 			})
 
 		case err, ok := <-w.Errors:
@@ -67,6 +82,30 @@ func watch(cfg *config.Config, embFS fs.FS, cfgPath string, hub *Hub) {
 			log.Printf("watcher error: %v", err)
 		}
 	}
+}
+
+// isConfigFile reports whether eventName refers to the same file as cfgPath
+// after resolving both to absolute paths.
+func isConfigFile(eventName, cfgPath string) bool {
+	a, err1 := filepath.Abs(eventName)
+	b, err2 := filepath.Abs(cfgPath)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return a == b
+}
+
+// reloadConfig loads cfgPath from disk and applies overrides on top.
+// Returns the fresh config, or an error if loading or overrides fail.
+func reloadConfig(cfgPath string, applyOverrides func(*config.Config) error) (*config.Config, error) {
+	fresh, err := config.Load(cfgPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := applyOverrides(fresh); err != nil {
+		return nil, err
+	}
+	return fresh, nil
 }
 
 // addDirRecursive adds root and every subdirectory under it to the watcher.

--- a/internal/server/watcher_test.go
+++ b/internal/server/watcher_test.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/engineervix/kwelea/internal/config"
+)
+
+// --- isConfigFile ---
+
+func TestIsConfigFile_SamePath(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "kwelea.toml")
+	if !isConfigFile(cfgPath, cfgPath) {
+		t.Fatal("same path should match")
+	}
+}
+
+func TestIsConfigFile_RelativeVsAbsolute(t *testing.T) {
+	abs, _ := filepath.Abs("kwelea.toml")
+	if !isConfigFile("kwelea.toml", abs) {
+		t.Fatal("relative vs absolute same file should match")
+	}
+}
+
+func TestIsConfigFile_DifferentFile(t *testing.T) {
+	tmp := t.TempDir()
+	a := filepath.Join(tmp, "kwelea.toml")
+	b := filepath.Join(tmp, "other.toml")
+	if isConfigFile(a, b) {
+		t.Fatal("different files should not match")
+	}
+}
+
+// --- reloadConfig ---
+
+func writeTOML(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReloadConfig_UpdatesDocsDir(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "kwelea.toml")
+	writeTOML(t, cfgPath, `
+[build]
+docs_dir = "new/docs"
+`)
+
+	got, err := reloadConfig(cfgPath, func(c *config.Config) error { return nil })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Build.DocsDir != "new/docs" {
+		t.Errorf("docs_dir: got %q, want %q", got.Build.DocsDir, "new/docs")
+	}
+}
+
+func TestReloadConfig_OverrideWins(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "kwelea.toml")
+	writeTOML(t, cfgPath, `
+[build]
+docs_dir = "toml/docs"
+`)
+
+	got, err := reloadConfig(cfgPath, func(c *config.Config) error {
+		c.Build.DocsDir = "cli/docs"
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Build.DocsDir != "cli/docs" {
+		t.Errorf("override wins: got %q, want %q", got.Build.DocsDir, "cli/docs")
+	}
+}
+
+func TestReloadConfig_BadTOML(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "kwelea.toml")
+	writeTOML(t, cfgPath, `not valid toml ][`)
+
+	_, err := reloadConfig(cfgPath, func(c *config.Config) error { return nil })
+	if err == nil {
+		t.Fatal("expected error for bad TOML, got nil")
+	}
+}
+
+func TestReloadConfig_MissingFile(t *testing.T) {
+	_, err := reloadConfig("/nonexistent/path/kwelea.toml", func(c *config.Config) error { return nil })
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestReloadConfig_OverrideError(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "kwelea.toml")
+	writeTOML(t, cfgPath, ``)
+
+	want := errors.New("override failed")
+	_, err := reloadConfig(cfgPath, func(c *config.Config) error { return want })
+	if !errors.Is(err, want) {
+		t.Fatalf("expected override error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- `rebuildAndReload` was reusing the in-memory `*config.Config` loaded at startup, so `kwelea.toml` edits (`docs_dir`, `output_dir`, `base_url`) were silently ignored until the server restarted
- Extract `isConfigFile` and `reloadConfig` helpers (independently testable)
- `watch` now detects config file events, reloads from disk, re-applies CLI overrides, then snapshots `currentCfg` into the debounce closure to avoid a data race
- Bad TOML is logged; the previous config is retained — server keeps running
- `server.Start` gains an `applyOverrides func(*config.Config) error` param; `serve.go` passes a closure over `applyFlagOverrides` so CLI flags always win after reload

Closes #38

## Test plan

- [ ] `go test ./internal/server/...` — 8 new tests all pass (`isConfigFile` × 3, `reloadConfig` × 5)
- [ ] `go test ./...` — no regressions
- [ ] `go build ./...` — clean
- [ ] Manual: `kwelea serve`, edit `kwelea.toml`, confirm "→ config reloaded" in logs and rebuild uses new values
- [ ] Manual: `kwelea serve --source content/docs`, edit `docs_dir` in toml, confirm CLI override still wins
- [ ] Manual: write bad TOML, confirm error logged and server keeps running